### PR TITLE
Persist slot limits across reloads

### DIFF
--- a/src/main/java/github/alecsio/mmceaddons/common/hatch/vanilla/TileSingularityItemBus.java
+++ b/src/main/java/github/alecsio/mmceaddons/common/hatch/vanilla/TileSingularityItemBus.java
@@ -2,6 +2,8 @@ package github.alecsio.mmceaddons.common.hatch.vanilla;
 
 import hellfirepvp.modularmachinery.common.block.prop.ItemBusSize;
 import hellfirepvp.modularmachinery.common.tiles.base.TileItemBus;
+import hellfirepvp.modularmachinery.common.util.IOInventory;
+import net.minecraft.nbt.NBTTagCompound;
 
 abstract public class TileSingularityItemBus extends TileItemBus {
 
@@ -9,5 +11,16 @@ abstract public class TileSingularityItemBus extends TileItemBus {
 
     public TileSingularityItemBus(ItemBusSize size) {
         super(size);
+    }
+    @Override
+    public void readCustomNBT(NBTTagCompound compound) {
+        super.readCustomNBT(compound);
+        NBTTagCompound inventoryTag = compound.getCompoundTag("inventory");
+        // super.readCustomNBT() restores the persisted backing inventory size,
+        // but creates a plain IOInventory without singularity slot limits.
+        int slotCount = this.inventory.getSlots();
+        IOInventory restored = buildInventory(this, slotCount);
+        restored.readNBT(inventoryTag);
+        this.inventory = restored;
     }
 }


### PR DESCRIPTION
super.readCustomNBT() restores the persisted backing inventory size,
but creates a plain IOInventory without singularity slot limits.


fixes: https://github.com/Alecsioo/MMCE-Addons/issues/44